### PR TITLE
add node_modules to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 !.gitignore
 .parcel-cache
 *.lock
+node_modules


### PR DESCRIPTION
I'm guessing pushing node modules is not intended, but if that's by design, you can ignore this PR (not sure if the `!.gitignore` is meant to cover node_modules but at least for me it doesn't)