### PR TITLE
remove text-transform to upper

### DIFF
--- a/client/index.scss
+++ b/client/index.scss
@@ -6,7 +6,6 @@ body {
 input {
   padding: 9px 25px;
   border-radius: 5px;
-  text-transform: uppercase;
 }
 
 #balance {
@@ -39,7 +38,6 @@ input {
 .button {
   display: inline-block;
   font-weight: bold;
-  text-transform: uppercase;
   border-radius: 5px;
   border: none;
   padding: 9px 25px;


### PR DESCRIPTION
Remove text-transform to uppercase so that any values used as input will go in unchanged to the eventual hash calculations 👍 